### PR TITLE
Add argument parsing for class file and optional sleep time

### DIFF
--- a/visualizer/__main__.py
+++ b/visualizer/__main__.py
@@ -1,24 +1,61 @@
+from argparse import ArgumentParser
+from constants import CLASS_FILE_PLACEHOLDER, Color, CMD_FILE_PATH, TEMPLATE_CMD_FILE_PATH
 from gdb import GDB
 from parser import Parser
 from printer import Printer
-import sys
+from os import remove
 from time import sleep
 
 
+def parse_args():
+    """ Parse and validates command line arguments
+
+    Returns:
+      classFile, sleep
+    """
+    arg_parser = ArgumentParser(
+        description="visualizer: visualize run-time behavior of TigerShrimp's Tracing JIT Compiler")
+    arg_parser.add_argument(
+        "file", help="JVM class file that the JIT compiler should run", type=str)
+    arg_parser.add_argument(
+        "--sleep", "-s", help="Sleep time between info frames, default 0.1", type=float, default=.1)
+    args = arg_parser.parse_args()
+    classFile = args.file
+    if classFile.endswith(".class"):
+        return classFile, args.sleep
+    else:
+        print("visualizer: {}error{}: given file should be an .class file".format(
+            Color.RED, Color.END))
+        exit(-1)
+
+
+def configure_gdb_commands_file(classFile):
+    """ Puts the classFile into the list of commands to GDB
+    """
+    with open(TEMPLATE_CMD_FILE_PATH, 'r') as template_file, open(CMD_FILE_PATH, 'w') as cmd_file:
+        contents = template_file.read()
+        contents = contents.replace(CLASS_FILE_PLACEHOLDER, classFile)
+        cmd_file.write(contents)
+
+
 def main():
-    sleepytime = float(sys.argv[1]) if len(sys.argv) > 1 else 0
-    gdb = GDB()
-    parser = Parser()
-    printer = Printer()
-    gdb.start()
-    stopped_reason = ""
-    while stopped_reason != "exited-normally":
-        gdb.write("continue\n")
-        output = gdb.read()
-        variables, registers, stopped_reason = parser.parse(output)
-        printer.print(variables, registers)
-        sleep(sleepytime)
-    gdb.stop()
+    classFile, sleepytime = parse_args()
+    configure_gdb_commands_file(classFile)
+    try:
+        gdb = GDB()
+        parser = Parser()
+        printer = Printer()
+        gdb.start()
+        stopped_reason = ""
+        while stopped_reason != "exited-normally":
+            gdb.write("continue\n")
+            output = gdb.read()
+            variables, registers, stopped_reason = parser.parse(output)
+            printer.print(variables, registers)
+            sleep(sleepytime)
+    finally:
+        remove(CMD_FILE_PATH)
+        gdb.stop()
 
 
 main()

--- a/visualizer/constants.py
+++ b/visualizer/constants.py
@@ -1,0 +1,8 @@
+CMD_FILE_PATH = "visualizer/commands.txt"
+TEMPLATE_CMD_FILE_PATH = "visualizer/template_commands.txt"
+CLASS_FILE_PLACEHOLDER = "##PLACEHOLDER_CLASS_FILE##"
+
+
+class Color:
+    RED = '\033[91m'
+    END = '\033[0m'

--- a/visualizer/gdb.py
+++ b/visualizer/gdb.py
@@ -1,3 +1,4 @@
+from constants import CMD_FILE_PATH
 from subprocess import PIPE, Popen
 from queue import Empty, Queue
 from threading import Thread
@@ -39,10 +40,10 @@ class GDB():
         """
         Starts the GDB subprocess and listens to its output to determine wether it started
         up without issues. If issues occurs with gdb, it will be restared until issues not
-        occur. (Runs gdb ../TracingJITCompiler/build/TigerShrimp -x commands.txt -q --interpreter=mi)
+        occur. (Runs gdb ../TracingJITCompiler/build/TigerShrimp -x "visualizer/commands.txt" -q --interpreter=mi)
         """
         cmd = ["gdb", "../TracingJITCompiler/build/TigerShrimp",
-               "-x", "visualizer/commands.txt", "-q", "--interpreter=mi"]
+               "-x", CMD_FILE_PATH, "-q", "--interpreter=mi"]
         self.gdb_process = Popen(cmd, stdout=PIPE, stdin=PIPE)
         self.reader = Reader(self.gdb_process)
         if self.check_startup():

--- a/visualizer/template_commands.txt
+++ b/visualizer/template_commands.txt
@@ -1,5 +1,5 @@
 b Interpreter.cpp:16
-run ../TracingJITCompiler/test/main.class
+run ##PLACEHOLDER_CLASS_FILE##
 display i
 display pc
 define hook-stop


### PR DESCRIPTION
Use argparse package to define program arguments. Required argument is now a JVM class file. This path to a JVM class file is inserted into the commands file that is given to GDB at startup,